### PR TITLE
adjust configure_requires to require Alien::Base::ModuleBuild

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -50,7 +50,7 @@ my $builder = $class->new (
 	module_name => 'Alien::OpenSSL',
 	license => 'perl',
 	configure_requires => {
-		'Alien::Base' => '0.025',
+		'Alien::Base::ModuleBuild' => '0.025',
 		'Module::Build' => '0.38',
 		'Test::More' => 0,
 	},


### PR DESCRIPTION
`Alien::Base::ModuleBuild` is the actual module that is needed at configure time (not Alien::Base).  In the future AB::MB may be a separate dist, so making this change will future proof this dist.
