### PR TITLE
uncomment ignore not found for ffi test

### DIFF
--- a/t/ffi.t
+++ b/t/ffi.t
@@ -14,7 +14,7 @@ note "dynamic=$_" for Alien::OpenSSL->dynamic_libs;
 
 ffi_ok with_subtest {
   my($ffi) = @_;
-  #$ffi->ignore_not_found(1);
+  $ffi->ignore_not_found(1);
   my $version_function = $ffi->function('OpenSSL_version' => ['int'] => 'string') ||
                          $ffi->function('SSLeay_version'  => ['int'] => 'string');
   ok($version_function, 'has SSLeay or OpenSSL _version function');


### PR DESCRIPTION
This should fix failures like this:

http://www.cpantesters.org/cpan/report/a99df746-c9cc-11e7-a8ee-2f7c19dcdcb4

I am sorry not sure why I commented that out, I think it must have been during testing, then I forgot to undo it.