### PR TITLE
macOS improvements and OPENSSL_PREFIX support

### DIFF
--- a/.github/workflows/macos-share.yml
+++ b/.github/workflows/macos-share.yml
@@ -1,0 +1,57 @@
+name: macos-share
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+
+env:
+  PERL5LIB: /Users/runner/perl5/lib/perl5
+  PERL_LOCAL_LIB_ROOT: /Users/runner/perl5
+  PERL_MB_OPT: --install_base /Users/runner/perl5
+  PERL_MM_OPT: INSTALL_BASE=/Users/runner/perl5
+  ALIEN_INSTALL_TYPE: share
+
+jobs:
+  perl:
+
+    runs-on: macOS-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Perl
+        run: |
+          brew install perl
+          curl https://cpanmin.us | perl - App::cpanminus -n
+          echo "##[add-path]/Users/runner/perl5/bin"
+
+      - name: perl -V
+        run: perl -V
+
+      - name: Prepare for cache
+        run: |
+          perl -V > perlversion.txt
+          ls -l perlversion.txt
+
+      - name: Cache CPAN modules
+        uses: actions/cache@v1
+        with:
+          path: ~/perl5
+          key: ${{ runner.os }}-build-share-${{ hashFiles('perlversion.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ hashFiles('perlversion.txt') }}
+
+      - name: Install Static Dependencies
+        run: |
+          cpanm -n Alien::Build
+      - name: Install Dynamic Dependencies
+        run: cpanm --installdeps .
+      - name: Run Tests
+        run: |
+          perl Makefile.PL
+          make
+          make test

--- a/.github/workflows/macos-system.yml
+++ b/.github/workflows/macos-system.yml
@@ -1,0 +1,58 @@
+name: macos-system
+
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+
+env:
+  PERL5LIB: /Users/runner/perl5/lib/perl5
+  PERL_LOCAL_LIB_ROOT: /Users/runner/perl5
+  PERL_MB_OPT: --install_base /Users/runner/perl5
+  PERL_MM_OPT: INSTALL_BASE=/Users/runner/perl5
+  ALIEN_INSTALL_TYPE: system
+
+jobs:
+  perl:
+
+    runs-on: macOS-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Perl
+        run: |
+          brew install perl
+          brew install libressl
+          curl https://cpanmin.us | perl - App::cpanminus -n
+          echo "##[add-path]/Users/runner/perl5/bin"
+
+      - name: perl -V
+        run: perl -V
+
+      - name: Prepare for cache
+        run: |
+          perl -V > perlversion.txt
+          ls -l perlversion.txt
+
+      - name: Cache CPAN modules
+        uses: actions/cache@v1
+        with:
+          path: ~/perl5
+          key: ${{ runner.os }}-build-system-${{ hashFiles('perlversion.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ hashFiles('perlversion.txt') }}
+
+      - name: Install Static Dependencies
+        run: |
+          cpanm -n Alien::Build
+      - name: Install Dynamic Dependencies
+        run: cpanm --installdeps .
+      - name: Run Tests
+        run: |
+          perl Makefile.PL
+          make
+          make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: perl
 perl:
+  - "dev"
+  - "5.30"
+  - "5.28"
+  - "5.26"
+  - "5.24"
   - "5.22"
   - "5.20"
   - "5.18"
@@ -11,8 +16,18 @@ perl:
 env:
   - ALIEN_INSTALL_TYPE=share
   - ALIEN_INSTALL_TYPE=system
+matrix:
+  allow_failures:
+    - perl: 5.8
+      env: ALIEN_INSTALL_TYPE=share
+before_install:
+  - eval $(curl https://travis-perl.github.io/init)
+  - build-perl
+  - perl -V
 install:
   - cpanm --notest Alien::Build~1.19
+  - cpanm --notest --installdeps .
 script:
-  - perl Makefile.PL && make manifest && perl Makefile.PL && make && make test
-  
+  - perl Makefile.PL
+  - (make 2>&1 > make.log) || (tail -5000 make.log && false)
+  - make test

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -32,8 +32,10 @@ WriteMakefile($abmm->mm_args(
 	},
 	"PREREQ_PM" => {
 		"Alien::Build" => "1.30",
+		"parent"       => "0",
 	},
 	"TEST_REQUIRES" => {
+		"Test2::V0"         => "0",
 		"Test::Alien::Diag" => "0",
 	},
 ));

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -33,6 +33,9 @@ WriteMakefile($abmm->mm_args(
 	"PREREQ_PM" => {
 		"Alien::Build" => "1.30",
 	},
+	"TEST_REQUIRES" => {
+		"Test::Alien::Diag" => "0",
+	},
 ));
 
 sub MY::postamble {

--- a/alienfile
+++ b/alienfile
@@ -2,6 +2,10 @@ use alienfile;
 use Config;
 use Env qw( @PKG_CONFIG_PATH @PKG_CONFIG_LIBDIR );
 
+if(defined $ENV{OPENSSL_PREFIX} && -d "$ENV{OPENSSL_PREFIX}/lib/pkgconfig") {
+  unshift @PKG_CONFIG_PATH, "$ENV{OPENSSL_PREFIX}/lib/pkgconfig";
+}
+
 if($^O eq 'darwin' && ! -d '/usr/include/openssl') {
   # The OpenSSL that ships with recent OS X is completely broken
   # from a developer perspective.  They provide an openssl binary,

--- a/alienfile
+++ b/alienfile
@@ -1,5 +1,36 @@
 use alienfile;
 use Config;
+use Env qw( @PKG_CONFIG_PATH @PKG_CONFIG_LIBDIR );
+
+if($^O eq 'darwin' && ! -d '/usr/include/openssl') {
+  # The OpenSSL that ships with recent OS X is completely broken
+  # from a developer perspective.  They provide an openssl binary,
+  # libraries and a .pc file, but no headers.  I guess the reason
+  # is OpenSSL is considered deprecated on the platform, but then
+  # why ship the .pc file?  We set PKG_CONFIG_LIBDIR to just the
+  # to skip /usr/lib/pkgconfig, unless the user has specified it.
+  # (presumably if they have set it, they have done so for a reason).
+  unless(defined $ENV{PKG_CONFIG_LIBDIR}) {
+    @PKG_CONFIG_LIBDIR = qw(
+      /usr/local/lib/pkgconfig
+      /usr/local/share/pkgconfig
+    )
+  }
+
+  if( -d '/usr/local/Cellar/openssl') {
+    require File::Glob;
+    my($dir) = File::Glob::bsd_glob('/usr/local/Cellar/openssl/*/lib/pkgconfig');
+    push @PKG_CONFIG_LIBDIR, $dir;
+  }
+
+  if( -d '/usr/local/Cellar/libressl') {
+    require File::Glob;
+    my($dir) = File::Glob::bsd_glob('/usr/local/Cellar/libressl/*/lib/pkgconfig');
+    push @PKG_CONFIG_LIBDIR, $dir;
+  }
+
+  log "overridding PKG_CONFIG_LIBDIR on macOS: $ENV{PKG_CONFIG_LIBDIR}";
+}
 
 plugin 'PkgConfig' => (
   pkg_name => 'openssl',

--- a/t/xs.t
+++ b/t/xs.t
@@ -1,8 +1,11 @@
 use Test2::V0;
 use Test::Alien;
 use Alien::OpenSSL;
+use Test::Alien::Diag qw( alien_diag );
 
 alien_ok 'Alien::OpenSSL';
+
+alien_diag 'Alien::OpenSSL';
 
 my $xs = do { local $/; <DATA> };
 


### PR DESCRIPTION
I'm working on a couple of improvements to `Alien::LibreSSL`, and I think `Alien::OpenSSL` can benefit from these enhancements as they relate to system installs.

 - honor the `OPENSSL_PREFIX` environment variable, as `Net::SSLeay` does.  The method that it uses isn't quite the same (we use pkg-config), but I think it is probably in practice more reliable.
 - on macOS use the homebrew openssl or libressl packages (in preference of that order), if available.  There is some extra logic because homebrew doesn't advertise the packages via pkg-config without changing the environment.  Out of an abundance of caution, we put this at the very end of the search list in case the user has specified their own search order to find the package that they want.
 - There is some logic to avoid detection of bad openssl on macOS (which has shipped for quite some time).  I believe it should be able to use the working system openssl on mac for older systems, but I don't have anything handy to test on (such systems aren't supported by Apple anymore anyway so not sure that it matters much).
 - There were a couple of prereqs that were missing.

For development:

 - I've added github actions to test macOS in CI.  There is a workflow for both a share and system install.
 - The travis-ci config was no longer working because of changes to the travis image, so I fixed it using the travis perl helper.