### PR TITLE
do not use lib64

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -119,7 +119,7 @@ share {
   if($system_type =~ /^(unix|windows-mingw)$/)
   {
     build [
-      './config --prefix=%{.install.prefix} shared',
+      './config --prefix=%{.install.prefix} --libdir=%{.install.prefix}/lib shared',
       '%{make}',
       '%{make} DESTDIR=%{env.DESTDIR} INSTALL_PREFIX=%{env.DESTDIR} install',
     ];
@@ -130,7 +130,7 @@ share {
     my $type = $Config{ptrsize} == 4 ? 'VC-WIN32' : 'VC-WIN64A';
     requires 'Alien::nasm' => '0.19';
     build [
-      "%{perl} Configure --prefix=%{.install.prefix} --openssldir=%{.runtime.prefix}/ssl no-shared $type",
+      "%{perl} Configure --prefix=%{.install.prefix} --libdir=%{.install.prefix}/lib --openssldir=%{.runtime.prefix}/ssl no-shared $type",
       '%{make}',
       '%{make} OPENSSLDIR=%{.install.prefix}/ssl install',
     ];

--- a/alienfile
+++ b/alienfile
@@ -118,6 +118,7 @@ share {
 
   if($system_type =~ /^(unix|windows-mingw)$/)
   {
+    plugin 'PkgConfig::MakeStatic';
     build [
       './config --prefix=%{.install.prefix} --libdir=%{.install.prefix}/lib shared',
       '%{make}',


### PR DESCRIPTION
OpenSSL helpfully installs libs to $PREFIX/lib64 on some platforms.  We don't want to do that for Alien.